### PR TITLE
Update JobPlacementsPanel.java

### DIFF
--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -414,9 +414,9 @@ public class JobPlacementsPanel extends JPanel {
     public final Action moveCameraToPlacementLocationNext = new AbstractAction() {
         {
             putValue(SMALL_ICON, Icons.centerCameraMoveNext);
-            putValue(NAME, "Move Camera To Placement Location and Move to Next Part");
+            putValue(NAME, "Move Camera To Next Placement Location ");
             putValue(SHORT_DESCRIPTION,
-                    "Position the camera at the placement's location and move to next part.");
+                    "Move to the next part and position the camera at its location.");
         }
 
         @Override
@@ -425,13 +425,13 @@ public class JobPlacementsPanel extends JPanel {
                 // Need to keep current focus owner so that the space bar can be
                 // used after the initial click. Otherwise, button focus is lost
                 // when table is updated
-                Component comp = MainFrame.get().getFocusOwner();
+            	Helpers.selectNextTableRow(table);
+            	Component comp = MainFrame.get().getFocusOwner();
                 Location location = Utils2D.calculateBoardPlacementLocation(boardLocation,
                         getSelection().getLocation());
                 Camera camera = MainFrame.get().getMachineControls().getSelectedTool().getHead()
                         .getDefaultCamera();
                 MovableUtils.moveToLocationAtSafeZ(camera, location);
-                Helpers.selectNextTableRow(table);
                 if (comp != null) {
                     comp.requestFocus();
                 }


### PR DESCRIPTION
# Description
Change the functionality of the Move camera to next placement button.

# Justification
Old behavior: The camera would move to the current location and the highlighted part would move to the next part. Then when you want to adjust the placement location you must select the part you are actually looking at as the next part is already selected in the placements panel.

New behavior: The highlighted part is moved and then the camera is moved to its location.
This way, the part in the camera view and the part highlighted in the parts list are the same. Then if you adjust the placement, when you press the "Set placement to current camera location" etc the correct part will be edited instead of the next part in the list.


# Instructions for Use
To quickly move the camera to the next placement in the placement table just press the "Move camera to next placement location".

This way you can quickly move around the job to check all placement locations just using one button.

# Implementation Details
1. How did you test the change? Be descriptive. Untested code will not be accepted.
To test, I compiled and ran openpnp and tested the function of the button I modified.
2. Did you follow the [coding style](https://github.com/openpnp/openpnp/wiki/Developers-Guide#coding-style)?
I think so..
3. If you made changes in the `org.openpnp.spi` or `org.openpnp.model` packages you will need to add additional justification for these changes. Changes to these packages require extensive review and testing.
No Changes here
4. Be sure to run `mvn test` before submitting the Pull Request. If the tests do not pass the Pull Request will not be accepted.
Ok
